### PR TITLE
Make rich text editor work on front end

### DIFF
--- a/classes/class-cf7rt-rich-text-editor.php
+++ b/classes/class-cf7rt-rich-text-editor.php
@@ -91,16 +91,13 @@ class CF7RT_Rich_Text_Editor{
 	    wp_editor( $value, $tag->name,$settings);
 	    $rich_editor = ob_get_contents();
 
-	    $html = '<span class="wpcf7-form-control-wrap '.$tag->name.'">'.$rich_editor.$validation_error.'</span>
-	    <script type="text/javascript">
-	    jQuery(document).ready(function() {
-	        jQuery(".wpcf7-form").submit(function(e){
-	            jQuery("#'.$tag->name.'").val(tinyMCE.get("'.$tag->name.'").getContent());
-	            return true;
-	        });
-	    });
-	    </script>';
-
+	    $html = '<span class="wpcf7-form-control-wrap '.$tag->name.'">'.$rich_editor.$validation_error.'</span>';
+		
+		wp_register_script( 'rich-text-editor', '', array("jquery",'wp-tinymce'), '', true );
+		wp_enqueue_script( 'rich-text-editor'  );
+		wp_add_inline_script( 'rich-text-editor','<script defer>jQuery(document).ready(function() { jQuery(".wpcf7-form").submit(function(e){ jQuery("#'.$tag->name.'").val(tinyMCE.get("'.$tag->name.'").getContent()); return true;	        });
+	    });</script>');
+	
 	    ob_end_clean();
 
 	    return $html;


### PR DESCRIPTION
The problem was that rich text editor was only working while you were logged in WordPress.
So in order to work on front end without the need of log in I enqueued the necessary scripts and used wp_add_inline_script hook to add the inline script code.